### PR TITLE
Add Cypress no-results test

### DIFF
--- a/cypress/e2e/no-results.cy.ts
+++ b/cypress/e2e/no-results.cy.ts
@@ -1,0 +1,25 @@
+describe('no results', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/getWatchData*', {
+      fixture: 'search_empty.json',
+      delayMs: 100,
+    }).as('searchEmpty')
+    cy.intercept('GET', '/_next/image*', {
+      body: '',
+      headers: { 'Content-Type': 'image/png' },
+    })
+  })
+
+  it('shows a message when no results are found', () => {
+    cy.visit('http://localhost:3000/')
+
+    cy.get('form').within(() => {
+      cy.get('input').type('abcdefg')
+      cy.contains('button', 'Search').click()
+    })
+
+    cy.get('.animate-pulse').should('have.length', 7)
+    cy.wait('@searchEmpty')
+    cy.contains(/Sorry|Second grade|Well that/).should('be.visible')
+  })
+})

--- a/cypress/fixtures/search_empty.json
+++ b/cypress/fixtures/search_empty.json
@@ -1,0 +1,6 @@
+{
+  "page": 1,
+  "results": [],
+  "total_pages": 1,
+  "total_results": 0
+}


### PR DESCRIPTION
## Summary
- add empty search fixture
- test no-results scenario with intercept and skeleton check

## Testing
- `npm run lint`
- `npm run test:codex`


------
https://chatgpt.com/codex/tasks/task_e_686fc402327883208f4ae4ade5668c4a