### PR TITLE
Add test for missing watch providers

### DIFF
--- a/cypress/e2e/result-no-providers.cy.ts
+++ b/cypress/e2e/result-no-providers.cy.ts
@@ -1,0 +1,39 @@
+describe('result page without certain watch providers', () => {
+  beforeEach(() => {
+    cy.intercept(
+      'GET',
+      'https://mnva0fhft9.execute-api.us-east-2.amazonaws.com/default/getWatchData*watchType=movie*',
+      { fixture: 'search_movie.json' },
+    ).as('searchMovie')
+    cy.intercept(
+      'GET',
+      '**/getWatchProviders*',
+      { fixture: 'watchProviders_movie_no_rent.json' },
+    ).as('providers')
+    cy.intercept(
+      'GET',
+      'https://elhxyyfpsi.execute-api.us-east-2.amazonaws.com/default/getWatchImage*',
+      { fixture: 'watchImage.json' },
+    ).as('watchImage')
+    cy.intercept('GET', '/_next/image*', {
+      body: '',
+      headers: { 'Content-Type': 'image/png' },
+    })
+  })
+
+  it('shows "none" when a provider category is empty', () => {
+    cy.visit('http://localhost:3000/')
+
+    cy.get('form').within(() => {
+      cy.get('input').type('lord of the rings')
+      cy.contains('button', 'Search').click()
+    })
+
+    cy.contains('Search results for "lord of the rings"')
+    cy.contains('The Lord of the Rings: The Return of the King').click()
+
+    cy.contains('h2', 'Rent')
+      .parent()
+      .contains('none')
+  })
+})

--- a/cypress/fixtures/watchProviders_movie_no_rent.json
+++ b/cypress/fixtures/watchProviders_movie_no_rent.json
@@ -1,0 +1,14 @@
+{
+  "id": 1,
+  "results": {
+    "US": {
+      "flatrate": [
+        {"provider_id": 8, "provider_name": "Netflix", "logo_path": "/netflix.png", "display_priority": 0}
+      ],
+      "buy": [
+        {"provider_id": 2, "provider_name": "Apple TV", "logo_path": "/apple.png", "display_priority": 0}
+      ],
+      "rent": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add fixture where rent providers are empty
- add Cypress test to confirm 'none' shows when providers missing

## Testing
- `npm run test:codex`

------
https://chatgpt.com/codex/tasks/task_e_686fc410c4dc832085f54fd0c924cea5