### PR TITLE
Add navigation link tests

### DIFF
--- a/cypress/e2e/nav-links.cy.ts
+++ b/cypress/e2e/nav-links.cy.ts
@@ -31,4 +31,32 @@ describe('navigation links', () => {
       .click()
     cy.wait('@devSite')
   })
+
+  it('opens TMDB website from footer', () => {
+    cy.intercept('GET', 'https://developer.themoviedb.org/**', {
+      statusCode: 200,
+      body: '<html></html>',
+    }).as('tmdb')
+    cy.visit('http://localhost:3000/search-results?query=lord&watchType=movie')
+    cy.wait('@searchMovie')
+    cy.get(
+      'footer a[href="https://developer.themoviedb.org/reference/intro/getting-started"]',
+    )
+      .invoke('attr', 'target', '_self')
+      .click()
+    cy.wait('@tmdb')
+  })
+
+  it('opens JustWatch website from footer', () => {
+    cy.intercept('GET', 'https://www.justwatch.com/**', {
+      statusCode: 200,
+      body: '<html></html>',
+    }).as('justwatch')
+    cy.visit('http://localhost:3000/search-results?query=lord&watchType=movie')
+    cy.wait('@searchMovie')
+    cy.get('footer a[href="https://www.justwatch.com/"]')
+      .invoke('attr', 'target', '_self')
+      .click()
+    cy.wait('@justwatch')
+  })
 })


### PR DESCRIPTION
## Summary
- add Cypress spec for NavBar and footer navigation links

## Testing
- `npm run lint`
- `npm run test:codex`


------
https://chatgpt.com/codex/tasks/task_e_686fc47b95c08320959efd670ac80ffb