### PR TITLE
Improve no-results assertion

### DIFF
--- a/cypress/e2e/no-results.cy.ts
+++ b/cypress/e2e/no-results.cy.ts
@@ -1,7 +1,9 @@
 describe('no results', () => {
+  const emptyResultsFixture = 'search_empty.json'
+
   beforeEach(() => {
     cy.intercept('GET', '**/getWatchData*', {
-      fixture: 'search_empty.json',
+      fixture: emptyResultsFixture,
       delayMs: 100,
     }).as('searchEmpty')
     cy.intercept('GET', '/_next/image*', {
@@ -20,6 +22,17 @@ describe('no results', () => {
 
     cy.get('.animate-pulse').should('have.length', 7)
     cy.wait('@searchEmpty')
-    cy.contains(/Sorry|Second grade|Well that/).should('be.visible')
+    const noResultsStrings = [
+      "Sorry, we don't have any matches for your imaginary movie! Care to search for something, you know, real? ;)",
+      'Second grade spelling bee champ you were not. Try again, you must. ;)',
+      "Well that's embarrasing... for you! What do you think this is a spell checker? ;)",
+    ]
+
+    cy.contains('p', /Sorry|Second grade|Well that/)
+      .should('be.visible')
+      .invoke('text')
+      .then((text) => {
+        expect(noResultsStrings).to.include(text)
+      })
   })
 })


### PR DESCRIPTION
## Summary
- reuse the empty results fixture in the no-results test
- check that the no-results message matches one of the defined strings

## Testing
- `npm run test:codex`

------
https://chatgpt.com/codex/tasks/task_e_686fc9a9854c8320867d8573530f52fd