### PR TITLE
Enable Cypress component tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ npm install
 | `npm run build` | Create an optimized production build.                    |
 | `npm start`     | Run the built application in production mode.            |
 | `npm run lint`  | Lint the project with ESLint.                            |
-| `npm test`      | Execute the Cypress test suite.                          |
+| `npm run test:e2e` | Execute the Cypress end-to-end tests.              |
+| `npm run test:ct`  | Execute Cypress component tests.                   |
 
-A pre-commit hook is configured to run `npm test` automatically, so commits may
+A pre-commit hook is configured to run `npm run test:codex` automatically, so commits may
 take a little longer to complete.
 
 ## Project structure
@@ -49,7 +50,7 @@ take a little longer to complete.
 - `src/app` – Next.js routes and shared components
 - `services` – helper functions that call the AWS endpoints
 - `types` – TypeScript type definitions
-- `cypress` – tests
+- `cypress` – end-to-end and component tests
 
 ## Todo
 

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,9 +1,30 @@
 import { defineConfig } from "cypress";
+import path from 'path';
 
 export default defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },
+  },
+  component: {
+    devServer: {
+      framework: 'react',
+      bundler: 'vite',
+      viteConfig: {
+        resolve: {
+          alias: {
+            'next/link': path.resolve(__dirname, 'cypress/stubs/NextLink.tsx'),
+            'next/image': path.resolve(__dirname, 'cypress/stubs/NextImage.tsx'),
+            'next/font/google': path.resolve(
+              __dirname,
+              'cypress/stubs/NextFont.tsx',
+            ),
+          },
+        },
+      },
+    },
+    specPattern: 'cypress/component/**/*.cy.{ts,tsx}',
+    supportFile: 'cypress/support/component.ts',
   },
 });

--- a/cypress/component/Button.cy.tsx
+++ b/cypress/component/Button.cy.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import Button from '../../src/app/_components/Button'
+import { mount } from 'cypress/react18'
+
+describe('Button', () => {
+  it('renders default button', () => {
+    mount(<Button>Click</Button>)
+    cy.get('button').should('have.class', 'rounded-lg')
+    cy.contains('Click')
+  })
+
+  it('applies custom classes', () => {
+    mount(<Button className="bg-red-500">Click</Button>)
+    cy.get('button').should('have.class', 'bg-red-500')
+    cy.get('button').should('not.have.class', 'bg-accent2')
+  })
+})

--- a/cypress/component/Footer.cy.tsx
+++ b/cypress/component/Footer.cy.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import Footer from '../../src/app/Footer'
+import { mount } from 'cypress/react18'
+
+describe('Footer', () => {
+  it('renders footer links', () => {
+    mount(<Footer />)
+    cy.get('footer').should('have.class', 'flex')
+    cy.contains('Privacy Policy')
+    cy.contains('©2024 Lucas Nethercott')
+  })
+})

--- a/cypress/component/LoadingSpinner.cy.tsx
+++ b/cypress/component/LoadingSpinner.cy.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import LoadingSpinner from '../../src/app/_components/LoadingSpinner'
+import { mount } from 'cypress/react18'
+
+describe('LoadingSpinner', () => {
+  it('renders spinner svg', () => {
+    mount(<LoadingSpinner />)
+    cy.get('svg').should('have.class', 'rounded-full')
+  })
+})

--- a/cypress/component/NavBar.cy.tsx
+++ b/cypress/component/NavBar.cy.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import NavBar from '../../src/app/NavBar'
+import { mount } from 'cypress/react18'
+
+describe('NavBar', () => {
+  it('renders nav with logo link', () => {
+    mount(<NavBar />)
+    cy.get('nav').should('have.class', 'flex')
+    cy.get('a[href="/"]').within(() => {
+      cy.get('img')
+    })
+  })
+})

--- a/cypress/component/Poster.cy.tsx
+++ b/cypress/component/Poster.cy.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import Poster from '../../src/app/_components/poster/Poster'
+import { mount } from 'cypress/react18'
+
+describe('Poster', () => {
+  it('renders image with alt text', () => {
+    mount(<Poster title="Test" poster_path="/path.jpg" />)
+    cy.get('img').should('have.attr', 'alt', 'Test poster')
+    cy.get('img').should('have.class', 'rounded-lg')
+  })
+})

--- a/cypress/component/PosterSkeleton.cy.tsx
+++ b/cypress/component/PosterSkeleton.cy.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import PosterSkeleton from '../../src/app/_components/poster/PosterSkeleton'
+import { mount } from 'cypress/react18'
+
+describe('PosterSkeleton', () => {
+  it('renders skeleton div', () => {
+    mount(<PosterSkeleton />)
+    cy.get('div').should('have.class', 'animate-pulse')
+  })
+})

--- a/cypress/component/SearchForm.cy.tsx
+++ b/cypress/component/SearchForm.cy.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import SearchForm from '../../src/app/_components/SearchForm'
+import { mount } from 'cypress/react18'
+import * as nextNavigation from 'next/navigation'
+
+describe('SearchForm', () => {
+  it('handles search submission', () => {
+    const push = cy.stub().as('push')
+    cy.stub(nextNavigation, 'useRouter').returns({ push })
+
+    mount(<SearchForm defaultQuery="start" />)
+
+    cy.get('input').should('have.value', 'start')
+    cy.contains('button', 'TV Shows').click()
+    cy.get('input').clear().type('hello world')
+    cy.contains('button', 'Search').click()
+
+    cy.get('@push').should(
+      'have.been.calledWith',
+      '/search-results?query=hello+world&watchType=tv',
+    )
+  })
+})

--- a/cypress/stubs/NextFont.tsx
+++ b/cypress/stubs/NextFont.tsx
@@ -1,0 +1,1 @@
+export const Poppins = () => ({ className: '' });

--- a/cypress/stubs/NextImage.tsx
+++ b/cypress/stubs/NextImage.tsx
@@ -1,0 +1,5 @@
+const NextImage = (props: any) => {
+  // eslint-disable-next-line @next/next/no-img-element
+  return <img {...props} />
+}
+export default NextImage

--- a/cypress/stubs/NextLink.tsx
+++ b/cypress/stubs/NextLink.tsx
@@ -1,0 +1,4 @@
+const NextLink = ({ href, children, ...rest }: any) => {
+  return <a href={href} {...rest}>{children}</a>
+}
+export default NextLink

--- a/cypress/support/component-index.html
+++ b/cypress/support/component-index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>
+    <div id="__cy_root" data-cy-root></div>
+  </body>
+</html>

--- a/cypress/support/component.ts
+++ b/cypress/support/component.ts
@@ -1,0 +1,15 @@
+import { mount } from 'cypress/react18'
+import '../../src/app/globals.css'
+import './commands'
+
+Cypress.Commands.add('mount', mount)
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      mount: typeof mount
+    }
+  }
+}
+
+export {}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,9 @@
 /** @type {import('next').NextConfig} */
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
 const nextConfig = {
   images: {
     remotePatterns: [
@@ -9,6 +14,17 @@ const nextConfig = {
         pathname: '/t/p/**',
       },
     ],
+  },
+  webpack: (config) => {
+    if (process.env.COMPONENT_TESTING) {
+      config.resolve = config.resolve || {}
+      config.resolve.alias = config.resolve.alias || {}
+      config.resolve.alias['next/font/google'] = path.resolve(
+        __dirname,
+        'cypress/stubs/NextFont.tsx',
+      )
+    }
+    return config
   },
 }
 

--- a/package.json
+++ b/package.json
@@ -7,12 +7,16 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "npx cypress run",
-    "test:xvfb": "xvfb-run -a npm run test",
-    "test:codex": "start-server-and-test dev 3000 test:xvfb"
+    "test:e2e": "npx cypress run",
+    "test:ct": "COMPONENT_TESTING=1 PORT=3000 npx cypress run --component",
+    "test:e2e:xvfb": "xvfb-run -a npm run test:e2e",
+    "test:ct:xvfb": "COMPONENT_TESTING=1 PORT=3000 xvfb-run -a npm run test:ct",
+    "test:xvfb": "npm run test:e2e:xvfb && npm run test:ct:xvfb",
+    "test:e2e:codex": "start-server-and-test dev http://localhost:3000 test:e2e:xvfb",
+    "test:codex": "npm run test:e2e:codex && npm run test:ct:xvfb"
   },
   "pre-commit": [
-    "test"
+    "test:codex"
   ],
   "dependencies": {
     "@next/third-parties": "^14.2.3",


### PR DESCRIPTION
## Summary
- configure component testing using Vite bundler and stub Next.js fonts
- add stub for `next/font/google`
- combine xvfb test scripts and rename them `test:e2e` and `test:ct`
- document new scripts in README

## Testing
- `npm run lint`
- `npm run test:codex` *(fails: Could not find "vite" in project's dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68702900821c83208f0d5c346d09b4d4