### PR TITLE
Add Cypress component tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -6,4 +6,10 @@ export default defineConfig({
       // implement node event listeners here
     },
   },
+  component: {
+    devServer: {
+      framework: 'next',
+      bundler: 'webpack',
+    },
+  },
 });

--- a/cypress/support/component.ts
+++ b/cypress/support/component.ts
@@ -1,0 +1,13 @@
+import { mount } from 'cypress/react18'
+import './commands'
+import '../../src/app/globals.css'
+
+Cypress.Commands.add('mount', mount)
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      mount: typeof mount
+    }
+  }
+}

--- a/src/app/Footer.cy.tsx
+++ b/src/app/Footer.cy.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import Footer from './Footer'
+
+describe('Footer', () => {
+  it('renders footer links', () => {
+    cy.mount(<Footer />)
+    cy.get('footer').within(() => {
+      cy.get('a[href*="themoviedb"]').should('exist')
+      cy.contains('a', 'Privacy Policy')
+      cy.contains('a', '©2024 Lucas Nethercott')
+    })
+  })
+})

--- a/src/app/NavBar.cy.tsx
+++ b/src/app/NavBar.cy.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import NavBar from './NavBar'
+
+describe('NavBar', () => {
+  it('renders logo link', () => {
+    cy.mount(<NavBar />)
+    cy.get('nav').find('a[href="/"]').find('img').should('exist')
+  })
+})

--- a/src/app/_components/Button.cy.tsx
+++ b/src/app/_components/Button.cy.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import Button from './Button'
+
+describe('Button', () => {
+  it('renders label and handles click', () => {
+    const onClick = cy.stub().as('click')
+    cy.mount(<Button onClick={onClick} className="bg-accent1">Test</Button>)
+    cy.contains('button', 'Test').should('have.class', 'bg-accent1')
+    cy.contains('button', 'Test').click()
+    cy.get('@click').should('have.been.called')
+  })
+})

--- a/src/app/_components/LoadingSpinner.cy.tsx
+++ b/src/app/_components/LoadingSpinner.cy.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import LoadingSpinner from './LoadingSpinner'
+
+describe('LoadingSpinner', () => {
+  it('renders spinner svg', () => {
+    cy.mount(<LoadingSpinner className="h-4 w-4" />)
+    cy.get('svg').should('have.class', 'h-4')
+  })
+})

--- a/src/app/_components/SearchForm.cy.tsx
+++ b/src/app/_components/SearchForm.cy.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import SearchForm from './SearchForm'
+import * as nextNav from 'next/navigation'
+import * as ga from '@next/third-parties/google'
+
+describe('SearchForm', () => {
+  it('changes watch type and submits search', () => {
+    const push = cy.stub().as('push')
+    cy.stub(nextNav, 'useRouter').returns({ push })
+    cy.stub(ga, 'sendGAEvent').as('ga')
+
+    cy.mount(
+      <SearchForm long defaultWatchType="movie" defaultQuery="" />,
+    )
+
+    cy.contains('button', 'TV Shows').click()
+    cy.contains('button', 'TV Shows').should('have.class', 'border-b-2')
+    cy.get('input').type('example title')
+    cy.get('button[type="submit"]').click()
+    cy.get('@push').should(
+      'have.been.calledWith',
+      '/search-results?query=example+title&watchType=tv',
+    )
+    cy.get('@ga').should('have.been.called')
+  })
+})

--- a/src/app/_components/poster/Poster.cy.tsx
+++ b/src/app/_components/poster/Poster.cy.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import Poster from './Poster'
+
+describe('Poster', () => {
+  it('renders image with alt text', () => {
+    cy.mount(<Poster title="Test" poster_path="/img.jpg" />)
+    cy.get('img[alt="Test poster"]').should('have.class', 'rounded-lg')
+  })
+})

--- a/src/app/_components/poster/PosterSkeleton.cy.tsx
+++ b/src/app/_components/poster/PosterSkeleton.cy.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import PosterSkeleton from './PosterSkeleton'
+
+describe('PosterSkeleton', () => {
+  it('renders loading skeleton', () => {
+    cy.mount(<PosterSkeleton />)
+    cy.get('div').should('have.class', 'animate-pulse')
+  })
+})


### PR DESCRIPTION
## Summary
- add Cypress component test support
- create component tests for SearchForm, Button, Poster and others
- configure component testing in Cypress

## Testing
- `npm run lint`
- `npm run test:codex`
- `npx cypress run --component` *(fails: missing server)*

------
https://chatgpt.com/codex/tasks/task_e_6870782d10f883208213582587def13f